### PR TITLE
docs(README.md): fix typo causing invalid char ':'

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ aws s3api create-bucket \
 ```
 
 Make sure that you have the newest [Go SDK](https://aws.amazon.com/sdk-for-go/) installed, 
-supporting the image scanning feature. In addition, you need to `go get https://github.com/gorilla/feeds`
+supporting the image scanning feature. In addition, you need to `go get github.com/gorilla/feeds`
 as the one other dependency outside of the standard library. Then execute:
 
 ```sh


### PR DESCRIPTION
Steps to reproduce:
```
go version
go version go1.16.3 darwin/amd64
```
```
go get https://github.com/gorilla/feeds
go get: malformed module path "https:/github.com/gorilla/feeds": invalid char ':'
```
```
go get github.com/gorilla/feeds
go: downloading github.com/gorilla/feeds v1.1.1
```
Why:
> the : character is [reserved on Windows](https://docs.microsoft.com/en-us/windows/desktop/fileio/naming-a-file#naming-conventions).
> https://github.com/golang/go/issues/28001#issuecomment-427031333